### PR TITLE
CmdAlias: UsageHelpText now works as the cmd's HelpText

### DIFF
--- a/CmdAliasPlugin/CmdAlias.cs
+++ b/CmdAliasPlugin/CmdAlias.cs
@@ -183,7 +183,7 @@ namespace Wolfje.Plugins.SEconomy.CmdAliasModule {
 				TShockAPI.Command newCommand = new TShockAPI.Command(aliasCmd.Permissions, ChatCommand_AliasExecuted, new string[] {
 					aliasCmd.CommandAlias,
 					"cmdalias." + aliasCmd.CommandAlias
-				}) { AllowServer = true };
+				}) { AllowServer = true, HelpText = aliasCmd.UsageHelpText };
 				TShockAPI.Commands.ChatCommands.Add(newCommand);
 			}
 		}


### PR DESCRIPTION
This allows players to retreive a cmdalias' UsageHelpText with ` /help cmdalias`.

It appears that "not implemented" means "if exception thrown, send this" at this point (https://github.com/tylerjwatson/SEconomy/blob/ace4396e376fc7487abc27aafc1dab9b7f2de817/CmdAliasPlugin/CmdAlias.cs#L326-L339). Mhm.